### PR TITLE
make require('pluggable-json') work by adding babel-plugin-add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["babel-plugin-add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.15",
     "babel-eslint": "^5.0.0-beta6",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "chai": "^3.4.1",


### PR DESCRIPTION
@mnibecker
