### PR TITLE
escape separators in object keys and array values

### DIFF
--- a/test/pluggable-json.spec.js
+++ b/test/pluggable-json.spec.js
@@ -48,10 +48,15 @@ describe("Pluggable JSON", () => {
             number: 1,
             boolean: true,
             string: "string",
+            "str:ing": "str:ing", // separator in object key and value
             null: null,
             array: [1, true, {a: "a string"}],
             object: {
-                b: [1, "a"],
+                b: [
+                    1,
+                    "a",
+                    "ab:cc" // separator in array value
+                ],
                 c: 2
             }
         };
@@ -81,6 +86,14 @@ describe("Pluggable JSON", () => {
 
             before(() => {
                 pluggableJSON = new PluggableJSON([durationSerializer]);
+            });
+
+            it("':' is the default separator", () => {
+                let obj = {
+                    "myDuration": myDuration
+                };
+
+                expect(Object.keys(pluggableJSON.serialize(obj, { toObject: true } ))[0]).to.contain(":");
             });
 
             it("value in object", () => {


### PR DESCRIPTION
This fixes the bug found in https://github.com/juttle/juttle-jsdp/issues/7.

The problem occurs when an array contains a value with occurrences of the default separator (`:`) and none of specified serializers apply to it. We _don't_ escape the separator and when we go to deserialize, we mistakenly treat the value as if it was serialized by a serializer, and try to find to determine the type of serializer and deserialize it that way.

In arrays: If the value is a string, escape the separators in the string so that we don't misread separators as encoding a serialized value when we go to deserialize.

In objects: Escape separators in the key even if the value isn't being serialized so that we don't misread separators as encoding a serialized value when we go to deserialize.

@mstemm @VladVega 
