### PR TITLE
use _.find instead of native Array.prototype.find

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ class PluggableJSON {
     }
 
     findSerializerForValue(value) {
-        return _.values(this._serializers).find((serializer) => {
+        return _.find(_.values(this._serializers), (serializer) => {
             return serializer.isSerializable(value);
         });
     }


### PR DESCRIPTION
For better compatibility with older browsers.

This is the cause of the `a.default.values(...).find is not a function` in https://github.com/juttle/juttle-engine/issues/93.

@rlgomes @mnibecker
